### PR TITLE
numbfs-utils: add timestamp support for inodes with validation tests

### DIFF
--- a/disk.h
+++ b/disk.h
@@ -74,6 +74,13 @@ struct numbfs_dirent {
 	__le16 ino;
 };
 
+struct numbfs_timestamps {
+	__le64 t_atime;
+	__le64 t_mtime;
+	__le64 t_ctime;
+	__u8 reserved[8];
+};
+
 /* on-disk xattr entry */
 struct numbfs_xattr_entry {
 	__u8 e_valid;
@@ -88,6 +95,7 @@ static inline void numbfs_check_ondisk(void)
 	NUMBFS_BUILD_BUG_ON(sizeof(struct numbfs_super_block) != 128);
 	NUMBFS_BUILD_BUG_ON(sizeof(struct numbfs_inode) != 64);
 	NUMBFS_BUILD_BUG_ON(sizeof(struct numbfs_dirent) != 64);
+	NUMBFS_BUILD_BUG_ON(sizeof(struct numbfs_timestamps) != 32);
 }
 
 #endif

--- a/internal.h
+++ b/internal.h
@@ -37,6 +37,7 @@ struct numbfs_inode_info {
         int gid;
         int size;
         int data[NUMBFS_NUM_DATA_ENTRY];
+        int xattr_start;
 };
 
 #define NUMBFS_BLOCKS_PER_BLOCK (BYTES_PER_BLOCK * BITS_PER_BYTE)


### PR DESCRIPTION
This PR introduces timestamp support for inodes in the numbfs-utils module and includes the necessary tests to ensure its correctness.